### PR TITLE
Add support pass array of Item class when call Complex.new

### DIFF
--- a/lib/growthforecast/complex.rb
+++ b/lib/growthforecast/complex.rb
@@ -8,7 +8,7 @@ class GrowthForecast::Complex
   attr_accessor :number, :data, :created_at, :updated_at
 
   # TODO strict validations
-  
+
   def initialize(obj)
     if obj.is_a?(String)
       obj = JSON.parse(obj)
@@ -28,7 +28,7 @@ class GrowthForecast::Complex
     @description = obj[:description]
     @sort = (obj[:sort] || 19).to_i
     @sumup = obj[:sumup] ? true : false
-    @data = (obj[:data] || []).map{|d| Item.new(d)}
+    @data = (obj[:data] || []).map{|d| d.is_a?(Item) ? d : Item.new(d)}
     @number = (obj[:number] || 0).to_i
     @created_at = obj[:created_at] ? Time.strptime(obj[:created_at], GrowthForecast::TIME_FORMAT) : nil
     @updated_at = obj[:updated_at] ? Time.strptime(obj[:updated_at], GrowthForecast::TIME_FORMAT) : nil


### PR DESCRIPTION
I want to add complex and wrote this:

``` ruby
spec = GrowthForecast::Complex.new({
  ...
  data: [
    GrowthForecast::Complex::Item.new({ graph_id: 1, type: 'LINE2', gmode: 'gauge', stack: true }),
  ]
})
```

I got the message:

``` ruby
/(...)/growthforecast-0.0.2/lib/growthforecast/complex.rb:61:in `initialize': undefined method `keys' for #<GrowthForecast::Complex::Item:0x007ff5619e6340> (NoMethodError)
        from /(...)/growthforecast-0.0.2/lib/growthforecast/complex.rb:31:in `new'

...
```

so, I wrote this patch. 

If this patch is not good, I think change the document.

`add_complex` part in README.md:

```
spec = GrowthForecast::Complex({
  service_name: 'example', section_name: 'test', graph_name: 'summary1',
  description: 'testing...', sumup: true,
  data: graph_id_list.map{|id| {graph_id: id, type: 'AREA', gmode: 'gauge', stack: true} }
})
```

What do you think about this?
